### PR TITLE
Change expected keys to match Evennia 0.7, and handle Evennia 0.6 keys 

### DIFF
--- a/bin/checkin.py
+++ b/bin/checkin.py
@@ -6,7 +6,7 @@ import platform
 
 url = 'http://127.0.0.1:8080/api/v1/game/check_in'
 values = {
-    'game_name': 'Test Güame',
+    'game_name': 'Test Güame Evennia 0.7',
     'game_status': 'pre-alpha',
     'game_website': 'http://blah.com',
     'listing_contact': 'blah@blah.com',
@@ -23,16 +23,33 @@ values = {
     'telnet_port': '1234',
     'web_client_url': 'http://webclient.blah.com',
 
-    'connected_player_count': 10,
-    'total_player_count': 123,
+    'connected_account_count': 10,
+    'total_account_count': 123,
 
-    'evennia_version': '0.5.0',
+    'evennia_version': '0.7.0',
     'python_version': platform.python_version(),
     'django_version': '1.8.x',
     'server_platform': platform.platform(),
 }
 data = urllib.urlencode(values)
 req = urllib2.Request(url, data)
+print("Testing Evennia 0.7 format request")
+try:
+    response = urllib2.urlopen(req)
+except urllib2.HTTPError as exc:
+    print exc.read()
+else:
+    result = response.read()
+    print result
+
+del values['connected_account_count']
+del values['total_account_count']
+values['game_name'] = "Test Güame Evennia 0.6"
+values['total_player_count'] = 123
+values['connected_player_count'] = 10
+data = urllib.urlencode(values)
+req = urllib2.Request(url, data)
+print("Testing Evennia 0.6 format request")
 try:
     response = urllib2.urlopen(req)
 except urllib2.HTTPError as exc:

--- a/egi/api_resources/gamelisting/checkin.py
+++ b/egi/api_resources/gamelisting/checkin.py
@@ -98,11 +98,20 @@ class GameListingCheckIn(Resource):
 
         # handle Evennia 0.6 and prior EGI keys
         if not args.connected_account_count \
-           and args.connect_player_count:
+           and args.connected_player_count:
             args.connected_account_count = args.connected_player_count
         if not args.total_account_count \
            and args.total_player_count:
             args.total_account_count = args.total_player_count
+
+        # Flask-restful's reqparser is acting a little odd.
+        # It reports True to hasattr, but throws an exception
+        # if we try del args.connected_player_count without it
+        # having been provided.
+        if args.connected_player_count is not None:
+            args.connected_player_count = None
+        if args.total_player_count is not None:
+            args.total_player_count = None
 
         # If it exists, we'll end up with the existing list. If not,
         # it gets created.

--- a/egi/api_resources/gamelisting/checkin.py
+++ b/egi/api_resources/gamelisting/checkin.py
@@ -103,6 +103,8 @@ class GameListingCheckIn(Resource):
         if not args.total_account_count \
            and args.total_player_count:
             args.total_account_count = args.total_player_count
+        # now that we're done with the old args, remove them
+        del args.total_player_count, args.connect_player_count
 
         # If it exists, we'll end up with the existing list. If not,
         # it gets created.

--- a/egi/api_resources/gamelisting/checkin.py
+++ b/egi/api_resources/gamelisting/checkin.py
@@ -103,8 +103,6 @@ class GameListingCheckIn(Resource):
         if not args.total_account_count \
            and args.total_player_count:
             args.total_account_count = args.total_player_count
-        # now that we're done with the old args, remove them
-        del args.total_player_count, args.connect_player_count
 
         # If it exists, we'll end up with the existing list. If not,
         # it gets created.

--- a/egi/api_resources/gamelisting/checkin.py
+++ b/egi/api_resources/gamelisting/checkin.py
@@ -46,11 +46,20 @@ post_parser.add_argument(
 )
 
 post_parser.add_argument(
-    'connected_player_count', dest='connected_player_count', type=int,
+    'connected_account_count', dest='connected_player_count', type=int,
     location='form', required=False,
 )
 post_parser.add_argument(
-    'total_player_count', dest='total_player_count', type=int,
+    'total_account_count', dest='total_player_count', type=int,
+    location='form', required=False,
+)
+
+post_parser.add_argument(
+    'connected_player_count', dest='fallback_connected_player_count', type=int,
+    location='form', required=False,
+)
+post_parser.add_argument(
+    'total_player_count', dest='fallback_total_player_count', type=int,
     location='form', required=False,
 )
 
@@ -86,6 +95,14 @@ class GameListingCheckIn(Resource):
                 not (args.telnet_hostname and args.telnet_port):
             abort(400, message="You must specify at least one of "
                                "web_client_url or telnet_hostname+telnet_port.")
+
+        # handle Evennia 0.6 and prior EGI keys
+        if not args.connected_player_count \
+           and args.fallback_connected_player_count:
+            args.connected_player_count = args.fallback_connected_player_count
+        if not args.total_player_count \
+           and args.fallback_total_player_count:
+            args.total_player_count = args.fallback_total_player_count
 
         # If it exists, we'll end up with the existing list. If not,
         # it gets created.

--- a/egi/api_resources/gamelisting/checkin.py
+++ b/egi/api_resources/gamelisting/checkin.py
@@ -46,20 +46,20 @@ post_parser.add_argument(
 )
 
 post_parser.add_argument(
-    'connected_account_count', dest='connected_player_count', type=int,
+    'connected_account_count', dest='connected_account_count', type=int,
     location='form', required=False,
 )
 post_parser.add_argument(
-    'total_account_count', dest='total_player_count', type=int,
+    'total_account_count', dest='total_account_count', type=int,
     location='form', required=False,
 )
 
 post_parser.add_argument(
-    'connected_player_count', dest='fallback_connected_player_count', type=int,
+    'connected_player_count', dest='connected_player_count', type=int,
     location='form', required=False,
 )
 post_parser.add_argument(
-    'total_player_count', dest='fallback_total_player_count', type=int,
+    'total_player_count', dest='total_player_count', type=int,
     location='form', required=False,
 )
 
@@ -97,12 +97,12 @@ class GameListingCheckIn(Resource):
                                "web_client_url or telnet_hostname+telnet_port.")
 
         # handle Evennia 0.6 and prior EGI keys
-        if not args.connected_player_count \
-           and args.fallback_connected_player_count:
-            args.connected_player_count = args.fallback_connected_player_count
-        if not args.total_player_count \
-           and args.fallback_total_player_count:
-            args.total_player_count = args.fallback_total_player_count
+        if not args.connected_account_count \
+           and args.connect_player_count:
+            args.connected_account_count = args.connected_player_count
+        if not args.total_account_count \
+           and args.total_player_count:
+            args.total_account_count = args.total_player_count
 
         # If it exists, we'll end up with the existing list. If not,
         # it gets created.

--- a/egi/api_resources/gamelisting/checkin.py
+++ b/egi/api_resources/gamelisting/checkin.py
@@ -108,10 +108,10 @@ class GameListingCheckIn(Resource):
         # It reports True to hasattr, but throws an exception
         # if we try del args.connected_player_count without it
         # having been provided.
-        if args.connected_player_count is not None:
-            args.connected_player_count = None
-        if args.total_player_count is not None:
-            args.total_player_count = None
+        if hasattr(args, 'connected_player_count'):
+            del args['connected_player_count']
+        if hasattr(args, 'total_player_count'):
+            del args['total_player_count']
 
         # If it exists, we'll end up with the existing list. If not,
         # it gets created.

--- a/egi/models.py
+++ b/egi/models.py
@@ -18,8 +18,8 @@ class GameListing(ndb.Model):
     web_client_url = ndb.StringProperty()
 
     # Game stats
-    connected_player_count = ndb.IntegerProperty()
-    total_player_count = ndb.IntegerProperty()
+    connected_account_count = ndb.IntegerProperty()
+    total_account_count = ndb.IntegerProperty()
 
     # System info
     evennia_version = ndb.StringProperty(required=True)

--- a/egi/models.py
+++ b/egi/models.py
@@ -39,7 +39,7 @@ class GameListing(ndb.Model):
         # Saves us from having to create an index, which is apparently slightly
         # more expensive (monetarily).
         return sorted(filtered_games, key=lambda game: (
-            (game.connected_player_count or 0) * -1, game.game_name))
+            (game.connected_account_count or 0) * -1, game.game_name))
 
     def is_fresh(self):
         cutoff_time = datetime.datetime.now() - datetime.timedelta(hours=2)

--- a/egi/templates/game_detail.html
+++ b/egi/templates/game_detail.html
@@ -47,7 +47,7 @@
     </tr>
     <tr>
       <th>Connected Players</th>
-      <td>{{ game.connected_player_count }}</td>
+      <td>{{ game.connected_account_count }}</td>
     </tr>
   </table>
   </div>

--- a/egi/templates/game_list.html
+++ b/egi/templates/game_list.html
@@ -64,7 +64,7 @@
           <em>None</em>
         {% endif %}
       </td>
-      <td>{{ game.connected_player_count }}</td>
+      <td>{{ game.connected_account_count }}</td>
       <td>
         {%- if game.telnet_hostname and game.telnet_port -%}
           <a href="telnet://{{ game.telnet_hostname }}:{{ game.telnet_port }}">Telnet</a>

--- a/egi/views/cron/metrics.py
+++ b/egi/views/cron/metrics.py
@@ -23,15 +23,15 @@ def report_all_game_iter_metrics():
             continue
         counters['fresh_game_listings'] += 1
 
-        if game.connected_player_count:
-            counters['connected_player_count'] += game.connected_player_count
-            GamePlayersConnected.write_gauge(game.connected_player_count, labels=game_labels)
-        if game.total_player_count:
-            counters['total_player_count'] += game.total_player_count
-            GamePlayersAll.write_gauge(game.total_player_count, labels=game_labels)
+        if game.connect_account_count:
+            counters['connected_account_count'] += game.connected_account_count
+            GamePlayersConnected.write_gauge(game.connected_account_count, labels=game_labels)
+        if game.total_account_count:
+            counters['total_account_count'] += game.total_account_count
+            GamePlayersAll.write_gauge(game.total_account_count, labels=game_labels)
 
-    EvenniaPlayerConnected.write_gauge(counters['connected_player_count'])
-    EvenniaPlayersAll.write_gauge(counters['total_player_count'])
+    EvenniaPlayerConnected.write_gauge(counters['connected_account_count'])
+    EvenniaPlayersAll.write_gauge(counters['total_account_count'])
     EDGGameListingsAll.write_gauge(counters['all_game_listings'])
     EDGGameListingsFresh.write_gauge(counters['fresh_game_listings'])
 


### PR DESCRIPTION
Changes the parser to accept Evennia 0.7's connected_account_count and total_account_count, as well as fallback to Evennia 0.6 and prior's connected_player_count and total_player_count.

Doesn't change the model fields - I wasn't sure of the ramifications of that.